### PR TITLE
Fix formatter for Vim9 users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Besides the base SMT-LIB2 language, this plugin also **supports the extensions o
 *Note: To provide a familiar experience, the syntax highlighting is directly derived from the source of [Z3's online demo](https://rise4fun.com/Z3/).*
 
 **Without an SMT solver** being installed, both the highlighting and the following shortcuts will be available:
-* `<localleader>f` auto-formats the current paragraph (uses `vim9script` and requires Vim >= v8.2.2725)
-* `<localleader>F` auto-formats the current buffer/file (uses `vim9script` and requires Vim >= v8.2.2725)
+* `<localleader>f` auto-formats the current paragraph (requires Vim 9)
+* `<localleader>F` auto-formats the current buffer/file (requires Vim 9)
 
 **With an SMT solver** of your choice being installed (*defaults to [Z3](https://github.com/Z3Prover/z3) or [boolector](http://fmv.jku.at/boolector)*), the following shortcuts will also be available:
 * `<localleader>r` evaluates the current file (in a terminal)

--- a/autoload/smt2/formatter.vim
+++ b/autoload/smt2/formatter.vim
@@ -1,6 +1,6 @@
 " Formatting requires a rather recent Vim version
-if (v:version < 802) || (v:version == 802 && !has("patch2725"))
-    const s:errmsg_oldvim = "Vim >= 8.2.2725 required for auto-formatting"
+if !has("vim9script")
+    const s:errmsg_oldvim = "Auto-formatting requires a Vim version with vim9script support."
 
     "Dummies
     function! smt2#formatter#FormatCurrentParagraph()
@@ -54,7 +54,6 @@ def FormatOneLine(ast: dict<any>): string
         return ast.value[0]->FormatOneLine()
     endif
     throw 'Cannot format AST node: ' .. string(ast)
-    return '' # Unreachable
 enddef
 
 def Format(ast: dict<any>, indent = 0): string
@@ -95,13 +94,11 @@ def Format(ast: dict<any>, indent = 0): string
         return formatted->join("\n\n")
     endif
     throw 'Cannot format AST node: ' .. string(ast)
-    return '' # Unreachable
 enddef
 
 # ------------------------------------------------------------------------------
 # Auxiliary
 # ------------------------------------------------------------------------------
-
 def FormatInCurrentBuffer(ast: dict<any>)
     const cursor = getpos('.')
 
@@ -123,7 +120,7 @@ def FormatInCurrentBuffer(ast: dict<any>)
     endif
 
     # Replace section of AST by formatted lines (w/o killing surrounding text)
-    deletebufline('%', ast_coords[0].line, ast_coords[1].line)
+    :silent deletebufline('%', ast_coords[0].line, ast_coords[1].line)
     if !empty(last_line_part_to_keep)
         last_line_part_to_keep->append(ast_coords[0].line - 1)
     endif
@@ -145,17 +142,17 @@ enddef
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
-def smt2#formatter#FormatCurrentParagraph()
+export def FormatCurrentParagraph()
     const ast = smt2#parser#ParseCurrentParagraph()
     FormatInCurrentBuffer(ast)
 enddef
 
-def smt2#formatter#FormatOutermostSExpr()
+export def FormatOutermostSExpr()
     const ast = smt2#parser#ParseOutermostSExpr()
     FormatInCurrentBuffer(ast)
 enddef
 
-def smt2#formatter#FormatFile()
-    const ast = smt2#parser#ParseFile()
+export def FormatFile()
+    const ast = smt2#parser#ParseBuffer()
     FormatInCurrentBuffer(ast)
 enddef

--- a/autoload/smt2/parser.vim
+++ b/autoload/smt2/parser.vim
@@ -295,7 +295,7 @@ enddef
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
-def smt2#parser#ParseCurrentParagraph(): dict<any>
+export def ParseCurrentParagraph(): dict<any>
     const cursor = getpos('.')
     MoveToStartOfCurrentParagraph()
     const from = getpos('.')
@@ -314,7 +314,7 @@ def smt2#parser#ParseCurrentParagraph(): dict<any>
     return ast
 enddef
 
-def smt2#parser#ParseOutermostSExpr(): dict<any>
+export def ParseOutermostSExpr(): dict<any>
     const cursor = getpos('.')
     if ! MoveToOutermostSExpr()
         throw "Cursor is not in an S-expression!"
@@ -335,7 +335,7 @@ def smt2#parser#ParseOutermostSExpr(): dict<any>
     return ast
 enddef
 
-def smt2#parser#ParseFile(): dict<any>
+export def ParseBuffer(): dict<any>
     const cursor = getpos('.')
     cursor(1, 1)
     const first_non_empty_line = search('.')

--- a/autoload/smt2/scanner.vim
+++ b/autoload/smt2/scanner.vim
@@ -52,7 +52,7 @@ enddef
 
 def PrettyPrint(scanner: dict<any>, token: dict<any>)
     const coord = scanner->Pos2Coord(token.pos)
-    echo printf("%5d %4d:%-3d  %8s %s", token.pos, coord.line, coord.col, token.kind->smt2#scanner#TokenKind2Str(), token.lexeme)
+    echo printf("%5d %4d:%-3d  %8s %s", token.pos, coord.line, coord.col, token.kind->TokenKind2Str(), token.lexeme)
 enddef
 
 # ------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ export def Scanner(source: string, start_line = 1, start_col = 1): dict<any>
     scanner.cur_char_nr = scanner.cur_char->char2nr()
     scanner.chars_len = len(scanner.chars)
     scanner.cur_token = {}
-    scanner->smt2#scanner#NextToken()
+    scanner->NextToken()
     return scanner
 enddef
 
@@ -119,7 +119,7 @@ export def NextToken(scanner: dict<any>)
         elseif nr == 59 # ';'
             scanner.cur_token = scanner->ReadComment()
         else
-            scanner->smt2#scanner#Enforce(false, printf("Unexpected character '%s'", scanner.cur_char), scanner.pos)
+            scanner->Enforce(false, printf("Unexpected character '%s'", scanner.cur_char), scanner.pos)
         endif
     endif
 
@@ -130,7 +130,7 @@ export def NextToken(scanner: dict<any>)
 enddef
 
 def NextPos(scanner: dict<any>)
-    if debug | scanner->smt2#scanner#Enforce(!scanner.at_eof, "Already at EOF", scanner.pos) | endif
+    if debug | scanner->Enforce(!scanner.at_eof, "Already at EOF", scanner.pos) | endif
 
     scanner.pos += 1
     scanner.at_eof = scanner.pos == scanner.chars_len
@@ -186,7 +186,7 @@ enddef
 # Note: The source string has all lines joined by "\n" so "\r" can be ignored
 # ------------------------------------------------------------------------------
 def ReadComment(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char == ';', "Not the start of a comment", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char == ';', "Not the start of a comment", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()
@@ -208,13 +208,13 @@ def IsDigit(char_nr: number): bool
 enddef
 
 def ReadNumber(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char_nr->IsDigit(), "Not the start of a number", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char_nr->IsDigit(), "Not the start of a number", scanner.pos) | endif
 
     const starts_with_zero = scanner.cur_char == '0'
     const start_pos = scanner.pos
     scanner->NextPos()
     # Note: We aren't strict about numbers not starting with 0 when not debugging
-    if debug | scanner->smt2#scanner#Enforce(!starts_with_zero || scanner.cur_char != '0', "Numeral may not start with 0", scanner.pos) | endif
+    if debug | scanner->Enforce(!starts_with_zero || scanner.cur_char != '0', "Numeral may not start with 0", scanner.pos) | endif
 
     var is_decimal = false
     while !scanner.at_eof
@@ -256,13 +256,13 @@ enddef
 const is_alphanumeric_char_nr = InitIsAlphaNumericCharNr()
 
 def ReadBv(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char == '#', "Not the start of a bit vector literal", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char == '#', "Not the start of a bit vector literal", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()
     if scanner.cur_char == 'x'
         scanner->NextPos()
-        scanner->smt2#scanner#Enforce(!scanner.at_eof && is_alphanumeric_char_nr[scanner.cur_char_nr],
+        scanner->Enforce(!scanner.at_eof && is_alphanumeric_char_nr[scanner.cur_char_nr],
             "hexadecimal literal may not be empty",
             scanner.pos)
         while !scanner.at_eof && is_alphanumeric_char_nr[scanner.cur_char_nr]
@@ -271,14 +271,14 @@ def ReadBv(scanner: dict<any>): dict<any>
     elseif scanner.cur_char == 'b'
         scanner->NextPos()
         # '0'->char2nr() == 48 && '1'->char2nr() == 49
-        scanner->smt2#scanner#Enforce(!scanner.at_eof && scanner.cur_char_num == 48 || scanner.cur_char_num == 49,
+        scanner->Enforce(!scanner.at_eof && scanner.cur_char_num == 48 || scanner.cur_char_num == 49,
             "binary literal may not be empty",
             scanner.pos)
         while !scanner.at_eof && scanner.cur_char_num == 48 || scanner.cur_char_num == 49
             scanner->NextPos()
         endwhile
     else
-        scanner->smt2#scanner#Enforce(false, "invalid bit vector literal -- expected 'x' or 'b'", scanner.pos)
+        scanner->Enforce(false, "invalid bit vector literal -- expected 'x' or 'b'", scanner.pos)
     endif
     return Token(token_bv, start_pos, scanner.chars[start_pos : scanner.pos - 1]->join(''))
 enddef
@@ -289,12 +289,12 @@ enddef
 # ------------------------------------------------------------------------------
 # TODO: Allow only printable characters, i.e. ranges [32, 126], [128-255]?
 def ReadString(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char == '"', "Not the start of a string", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char == '"', "Not the start of a string", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()
     while true
-        scanner->smt2#scanner#Enforce(!scanner.at_eof, "unexpected end of string", scanner.pos)
+        scanner->Enforce(!scanner.at_eof, "unexpected end of string", scanner.pos)
 
         if scanner.cur_char == '"'
             scanner->NextPos()
@@ -331,7 +331,7 @@ def IsStartOfSimpleSymbol(char_nr: number): bool
 enddef
 
 def ReadSimpleSymbol(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char_nr->IsStartOfSimpleSymbol(), "Not the start of a simple symbol", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char_nr->IsStartOfSimpleSymbol(), "Not the start of a simple symbol", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()
@@ -348,13 +348,13 @@ enddef
 # ------------------------------------------------------------------------------
 # TODO: Allow only printable characters, i.e. ranges [32, 126], [128-255]?
 def ReadQuotedSymbol(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char == '|', "Not the start of a quoted symbol", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char == '|', "Not the start of a quoted symbol", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()
     while true
-        scanner->smt2#scanner#Enforce(!scanner.at_eof, "unexpected end of quoted symbol", scanner.pos)
-        scanner->smt2#scanner#Enforce(scanner.cur_char != '\\', "quoted symbol may not contain '\'", scanner.pos)
+        scanner->Enforce(!scanner.at_eof, "unexpected end of quoted symbol", scanner.pos)
+        scanner->Enforce(scanner.cur_char != '\\', "quoted symbol may not contain '\'", scanner.pos)
         if scanner.cur_char == '|'
             break
         endif
@@ -368,7 +368,7 @@ enddef
 # <keyword> ::= :<simple symbol>
 # ------------------------------------------------------------------------------
 def ReadKeyword(scanner: dict<any>): dict<any>
-    if debug | scanner->smt2#scanner#Enforce(scanner.cur_char == ':', "Not the start of a keyword", scanner.pos) | endif
+    if debug | scanner->Enforce(scanner.cur_char == ':', "Not the start of a keyword", scanner.pos) | endif
 
     const start_pos = scanner.pos
     scanner->NextPos()

--- a/autoload/smt2/scanner.vim
+++ b/autoload/smt2/scanner.vim
@@ -23,7 +23,7 @@ def Token(kind: number, pos: number, lexeme: string): dict<any>
     return {kind: kind, pos: pos, lexeme: lexeme}
 enddef
 
-def smt2#scanner#TokenKind2Str(kind: number): string
+export def TokenKind2Str(kind: number): string
     if kind == token_lparen
         return "LParen"
     elseif kind == token_rparen
@@ -68,7 +68,7 @@ enddef
 # TODO: Enforce restriction to ASCII? We should if we use the lookup table below
 # TODO: Do not take a string but a character stream (or just buffer and pos)?
 
-def smt2#scanner#Scanner(source: string, start_line = 1, start_col = 1): dict<any>
+export def Scanner(source: string, start_line = 1, start_col = 1): dict<any>
     var scanner = {
         chars: source->trim(" \n\r\t", 2)->split('\zs'),
         line_offset: start_line, # start line of source string in buffer
@@ -91,7 +91,7 @@ def smt2#scanner#Scanner(source: string, start_line = 1, start_col = 1): dict<an
     return scanner
 enddef
 
-def smt2#scanner#NextToken(scanner: dict<any>)
+export def NextToken(scanner: dict<any>)
     if scanner.at_eof
         scanner.cur_token = Token(token_eof, scanner.pos, '')
     else
@@ -138,7 +138,7 @@ def NextPos(scanner: dict<any>)
     scanner.cur_char_nr = scanner.cur_char->char2nr()
 enddef
 
-def smt2#scanner#Enforce(scanner: dict<any>, expr: bool, msg: string, pos: number)
+export def Enforce(scanner: dict<any>, expr: bool, msg: string, pos: number)
     if !expr
         const coord = scanner->Pos2Coord(pos)
         throw printf("Syntax error (at %d:%d): %s ", coord.line, coord.col, msg)

--- a/ftplugin/smt2.vim
+++ b/ftplugin/smt2.vim
@@ -22,10 +22,6 @@ endif
 " ------------------------------------------------------------------------------
 " Mappings for formatting functionality
 " ------------------------------------------------------------------------------
-if has("vim9script")
-    import autoload 'smt2/formatter.vim'
-endif
-
 nnoremap <silent> <buffer> <Plug>Smt2FormatCurrentParagraph :call smt2#formatter#FormatCurrentParagraph()<cr>
 if !hasmapto('<Plug>Smt2FormatCurrentParagraph', 'n') && (mapcheck('<localleader>f', 'n') == '')
     nmap <silent> <localleader>f <Plug>Smt2FormatCurrentParagraph

--- a/ftplugin/smt2.vim
+++ b/ftplugin/smt2.vim
@@ -22,6 +22,10 @@ endif
 " ------------------------------------------------------------------------------
 " Mappings for formatting functionality
 " ------------------------------------------------------------------------------
+if has("vim9script")
+    import autoload 'smt2/formatter.vim'
+endif
+
 nnoremap <silent> <buffer> <Plug>Smt2FormatCurrentParagraph :call smt2#formatter#FormatCurrentParagraph()<cr>
 if !hasmapto('<Plug>Smt2FormatCurrentParagraph', 'n') && (mapcheck('<localleader>f', 'n') == '')
     nmap <silent> <localleader>f <Plug>Smt2FormatCurrentParagraph


### PR DESCRIPTION
While vim9script was in development public symbols were allowed to contain `#`. However, vim9script eventually disallowed this and now also requires explicit export/import of symbols. With this change we follow the expected, new way of expressing "public" symbols.

Closes #5