### PR TITLE
Replace dicts by classes

### DIFF
--- a/autoload/smt2/formatter.vim
+++ b/autoload/smt2/formatter.vim
@@ -16,6 +16,7 @@ if !has("vim9script")
     finish
 endif
 vim9script
+import "./parser.vim"
 
 # ------------------------------------------------------------------------------
 # Config
@@ -33,7 +34,7 @@ endif
 # ------------------------------------------------------------------------------
 # Formatter
 # ------------------------------------------------------------------------------
-def FitsOneLine(ast: dict<any>): bool
+def FitsOneLine(ast: parser.Ast): bool
     # A paragraph with several entries should not be formatted in one line
     if ast.kind ==# 'Paragraph' && len(ast.value) != 1
         return false
@@ -41,7 +42,7 @@ def FitsOneLine(ast: dict<any>): bool
     return ast.pos_to - ast.pos_from < g:smt2_formatter_short_length && !ast.contains_comment
 enddef
 
-def FormatOneLine(ast: dict<any>): string
+def FormatOneLine(ast: parser.Ast): string
     if ast.kind ==# 'Atom'
         return ast.value.lexeme
     elseif ast.kind ==# 'SExpr'
@@ -56,7 +57,7 @@ def FormatOneLine(ast: dict<any>): string
     throw 'Cannot format AST node: ' .. string(ast)
 enddef
 
-def Format(ast: dict<any>, indent = 0): string
+def Format(ast: parser.Ast, indent = 0): string
     const indent_str = repeat(g:smt2_formatter_indent_str, indent)
 
     if ast.kind ==# 'Atom'
@@ -99,7 +100,7 @@ enddef
 # ------------------------------------------------------------------------------
 # Auxiliary
 # ------------------------------------------------------------------------------
-def FormatInCurrentBuffer(ast: dict<any>)
+def FormatInCurrentBuffer(ast: parser.Ast)
     const cursor = getpos('.')
 
     # Format lines and potential surrounding text on them

--- a/autoload/smt2/parser.vim
+++ b/autoload/smt2/parser.vim
@@ -1,4 +1,6 @@
 vim9script
+import "./scanner.vim" as scanner_ns
+
 const debug = false
 set maxfuncdepth=100000000 # SMT files tend to be highly nested
 
@@ -59,7 +61,7 @@ def SExprAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: 
     return Ast('SExpr', exprs, pos_from, pos_to, contains_comment, scanner)
 enddef
 
-def AtomAst(token: dict<any>, scanner: dict<any>): dict<any>
+def AtomAst(token: scanner_ns.Token, scanner: dict<any>): dict<any>
     return Ast('Atom', token, token.pos, token.pos + len(token.lexeme), token.kind == 8, scanner)
 enddef
 
@@ -105,7 +107,7 @@ def AtStartOfLParen(scanner: dict<any>): bool
     return scanner.cur_token.kind == 0 # token_lparen
 enddef
 
-def ParseLParen(scanner: dict<any>): dict<any>
+def ParseLParen(scanner: dict<any>): scanner_ns.Token
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfLParen(),
             "ParseLParen called but not at start of LParen",
@@ -124,7 +126,7 @@ def AtStartOfRParen(scanner: dict<any>): bool
     return scanner.cur_token.kind == 1 # token_rparen
 enddef
 
-def ParseRParen(scanner: dict<any>): dict<any>
+def ParseRParen(scanner: dict<any>): scanner_ns.Token
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfRParen(),
             "ParseRParen called but not at start of RParen",

--- a/autoload/smt2/parser.vim
+++ b/autoload/smt2/parser.vim
@@ -7,6 +7,7 @@ set maxfuncdepth=100000000 # SMT files tend to be highly nested
 # TODO: Retry iterative parsing now that we have a scanner and simpler grammar
 # TODO: Refer to token kind by name, e.g. token_comment instead of 8
 # TODO: Change Ast.kind type from string to enum/number?
+# TODO: Now that vim9script has classes replace Ast dict<any> by class
 
 # ------------------------------------------------------------------------------
 # AST nodes
@@ -15,20 +16,20 @@ set maxfuncdepth=100000000 # SMT files tend to be highly nested
 #       function in the formatter.
 #       Here, pos_from and pos_to refer to indices of characters -- not tokens.
 # ------------------------------------------------------------------------------
-def Ast(kind: string, value: any, pos_from: number, pos_to: number, contains_comment: bool, scanner: dict<any>): dict<any>
+def Ast(kind: string, value: any, pos_from: number, pos_to: number, contains_comment: bool, scanner: scanner_ns.Scanner): dict<any>
     # User-facing functionality wants start/end line and column -- not positions
     def CalcCoords(): list<dict<number>>
-        const from = scanner.calcCoord(pos_from)
+        const from = scanner.CalcCoord(pos_from)
         # If expression ends at end of line, pos_to will be in next line.
         # That's undesired. Stay in the actual last line.
-        var to = scanner.calcCoord(pos_to - 1)
+        var to = scanner.CalcCoord(pos_to - 1)
         to.col += 1
         return [from, to]
     enddef
     return {kind: kind, value: value, pos_from: pos_from, pos_to: pos_to, contains_comment: contains_comment, CalcCoords: CalcCoords}
 enddef
 
-def FileAst(paragraphs: list<dict<any>>, pos_from: number, pos_to: number, scanner: dict<any>): dict<any>
+def FileAst(paragraphs: list<dict<any>>, pos_from: number, pos_to: number, scanner: scanner_ns.Scanner): dict<any>
     var contains_comment = false
     for paragraph in paragraphs
         if paragraph.contains_comment
@@ -39,7 +40,7 @@ def FileAst(paragraphs: list<dict<any>>, pos_from: number, pos_to: number, scann
     return Ast('File', paragraphs, pos_from, pos_to, contains_comment, scanner)
 enddef
 
-def ParagraphAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: dict<any>): dict<any>
+def ParagraphAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: scanner_ns.Scanner): dict<any>
     var contains_comment = false
     for expr in exprs
         if expr.contains_comment
@@ -50,7 +51,7 @@ def ParagraphAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scann
     return Ast('Paragraph', exprs, pos_from, pos_to, contains_comment, scanner)
 enddef
 
-def SExprAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: dict<any>): dict<any>
+def SExprAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: scanner_ns.Scanner): dict<any>
     var contains_comment = false
     for expr in exprs
         if expr.contains_comment
@@ -61,7 +62,7 @@ def SExprAst(exprs: list<dict<any>>, pos_from: number, pos_to: number, scanner: 
     return Ast('SExpr', exprs, pos_from, pos_to, contains_comment, scanner)
 enddef
 
-def AtomAst(token: scanner_ns.Token, scanner: dict<any>): dict<any>
+def AtomAst(token: scanner_ns.Token, scanner: scanner_ns.Scanner): dict<any>
     return Ast('Atom', token, token.pos, token.pos + len(token.lexeme), token.kind == 8, scanner)
 enddef
 
@@ -103,11 +104,11 @@ enddef
 # ------------------------------------------------------------------------------
 # LParen
 # ------------------------------------------------------------------------------
-def AtStartOfLParen(scanner: dict<any>): bool
+def AtStartOfLParen(scanner: scanner_ns.Scanner): bool
     return scanner.cur_token.kind == 0 # token_lparen
 enddef
 
-def ParseLParen(scanner: dict<any>): scanner_ns.Token
+def ParseLParen(scanner: scanner_ns.Scanner): scanner_ns.Token
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfLParen(),
             "ParseLParen called but not at start of LParen",
@@ -122,11 +123,11 @@ enddef
 # ------------------------------------------------------------------------------
 # RParen
 # ------------------------------------------------------------------------------
-def AtStartOfRParen(scanner: dict<any>): bool
+def AtStartOfRParen(scanner: scanner_ns.Scanner): bool
     return scanner.cur_token.kind == 1 # token_rparen
 enddef
 
-def ParseRParen(scanner: dict<any>): scanner_ns.Token
+def ParseRParen(scanner: scanner_ns.Scanner): scanner_ns.Token
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfRParen(),
             "ParseRParen called but not at start of RParen",
@@ -141,11 +142,11 @@ enddef
 # ------------------------------------------------------------------------------
 # Atom
 # ------------------------------------------------------------------------------
-def AtStartOfAtom(scanner: dict<any>): bool
+def AtStartOfAtom(scanner: scanner_ns.Scanner): bool
     return 2 <= scanner.cur_token.kind && scanner.cur_token.kind <= 8
 enddef
 
-def ParseAtom(scanner: dict<any>): dict<any>
+def ParseAtom(scanner: scanner_ns.Scanner): dict<any>
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfAtom(),
             "ParseAtom called but not at start of Atom",
@@ -160,11 +161,11 @@ enddef
 # ------------------------------------------------------------------------------
 # Expr
 # ------------------------------------------------------------------------------
-def AtStartOfExpr(scanner: dict<any>): bool
+def AtStartOfExpr(scanner: scanner_ns.Scanner): bool
     return scanner->AtStartOfSExpr() || scanner->AtStartOfAtom()
 enddef
 
-def ParseExpr(scanner: dict<any>): dict<any>
+def ParseExpr(scanner: scanner_ns.Scanner): dict<any>
     if debug
         scanner->smt2#scanner#Enforce(scanner->AtStartOfExpr(),
             "ParseExpr called but not at start of Expr",
@@ -182,7 +183,7 @@ enddef
 # ------------------------------------------------------------------------------
 const AtStartOfSExpr = funcref(AtStartOfLParen)
 
-def ParseSExpr(scanner: dict<any>): dict<any>
+def ParseSExpr(scanner: scanner_ns.Scanner): dict<any>
     const pos_from = scanner.cur_token.pos
 
     if debug
@@ -210,7 +211,7 @@ enddef
 # ------------------------------------------------------------------------------
 # Paragraph
 # ------------------------------------------------------------------------------
-def ParseParagraph(scanner: dict<any>): dict<any>
+def ParseParagraph(scanner: scanner_ns.Scanner): dict<any>
     const pos_from = scanner.cur_token.pos
 
     # Expr+
@@ -230,7 +231,7 @@ enddef
 # ------------------------------------------------------------------------------
 # File
 # ------------------------------------------------------------------------------
-def ParseFile(scanner: dict<any>): dict<any>
+def ParseFile(scanner: scanner_ns.Scanner): dict<any>
     const pos_from = scanner.cur_token.pos
 
     var paragraphs = []
@@ -346,7 +347,7 @@ export def ParseBuffer(): dict<any>
     # source = [first non-empty line, EOF]
     const source = join(getline(first_non_empty_line, '$'), "\n")
 
-    var scanner = smt2#scanner#Scanner(source, first_non_empty_line)
+    var scanner = scanner_ns.Scanner.new(source, first_non_empty_line)
     const ast = scanner->ParseFile()
 
     if debug | ast->PrintAst() | endif

--- a/autoload/smt2/scanner.vim
+++ b/autoload/smt2/scanner.vim
@@ -55,11 +55,6 @@ export def TokenKind2Str(kind: number): string
     endif
 enddef
 
-def PrettyPrint(scanner: dict<any>, token: Token)
-    const coord = scanner->Pos2Coord(token.pos)
-    echo printf("%5d %4d:%-3d  %8s %s", token.pos, coord.line, coord.col, token.kind->TokenKind2Str(), token.lexeme)
-enddef
-
 # ------------------------------------------------------------------------------
 # Scanner
 #
@@ -73,30 +68,47 @@ enddef
 # TODO: Enforce restriction to ASCII? We should if we use the lookup table below
 # TODO: Do not take a string but a character stream (or just buffer and pos)?
 
-export def Scanner(source: string, start_line = 1, start_col = 1): dict<any>
-    var scanner = {
-        chars: source->trim(" \n\r\t", 2)->split('\zs'),
-        line_offset: start_line, # start line of source string in buffer
-        pos: start_col - 1,      # pos in source string -- not column in line
-        at_new_paragraph: false,
-    }
-    scanner.calcCoord = (pos: number): dict<number> => Pos2Coord(scanner, pos)
+export class Scanner
+    var chars: list<string>
+    var line_offset: number
+    public var pos: number
+    public var at_new_paragraph: bool
 
-    if scanner.chars->empty()
-        scanner.at_eof = true
-        scanner.cur_char = ''
-    else
-        scanner.at_eof = false
-        scanner.cur_char = scanner.chars[0]
-    endif
-    scanner.cur_char_nr = scanner.cur_char->char2nr()
-    scanner.chars_len = len(scanner.chars)
-    scanner.cur_token = {}
-    scanner->NextToken()
-    return scanner
+    public var at_eof: bool
+    public var cur_char: string
+    public var cur_char_nr: number
+    var chars_len: number
+    public var cur_token: Token
+
+    def new(source: string, start_line = 1, start_col = 1)
+        this.chars = source->trim(" \n\r\t", 2)->split('\zs')
+        this.line_offset = start_line # start line of source string in buffer
+        this.pos = start_col - 1      # pos in source string -- not column in line
+        this.at_new_paragraph = false
+
+        if this.chars->empty()
+            this.at_eof = true
+            this.cur_char = ''
+        else
+            this.at_eof = false
+            this.cur_char = this.chars[0]
+        endif
+        this.cur_char_nr = this.cur_char->char2nr()
+        this.chars_len = len(this.chars)
+        this->NextToken()
+    enddef
+
+    def CalcCoord(pos: number): dict<number>
+        return Pos2Coord(this, pos)
+    enddef
+endclass
+
+def PrettyPrint(scanner: Scanner, token: Token)
+    const coord = scanner->Pos2Coord(token.pos)
+    echo printf("%5d %4d:%-3d  %8s %s", token.pos, coord.line, coord.col, token.kind->TokenKind2Str(), token.lexeme)
 enddef
 
-export def NextToken(scanner: dict<any>)
+export def NextToken(scanner: Scanner)
     if scanner.at_eof
         scanner.cur_token = Token.new(token_eof, scanner.pos, '')
     else
@@ -134,7 +146,7 @@ export def NextToken(scanner: dict<any>)
     endif
 enddef
 
-def NextPos(scanner: dict<any>)
+def NextPos(scanner: Scanner)
     if debug | scanner->Enforce(!scanner.at_eof, "Already at EOF", scanner.pos) | endif
 
     scanner.pos += 1
@@ -143,7 +155,7 @@ def NextPos(scanner: dict<any>)
     scanner.cur_char_nr = scanner.cur_char->char2nr()
 enddef
 
-export def Enforce(scanner: dict<any>, expr: bool, msg: string, pos: number)
+export def Enforce(scanner: Scanner, expr: bool, msg: string, pos: number)
     if !expr
         const coord = scanner->Pos2Coord(pos)
         throw printf("Syntax error (at %d:%d): %s ", coord.line, coord.col, msg)
@@ -151,7 +163,7 @@ export def Enforce(scanner: dict<any>, expr: bool, msg: string, pos: number)
 enddef
 
 # This is slow and intended for use in error messages & debugging only
-def Pos2Coord(scanner: dict<any>, pos: number): dict<number>
+def Pos2Coord(scanner: Scanner, pos: number): dict<number>
     const line = scanner.chars[: pos]->count("\n") + scanner.line_offset
 
     var cur_pos = pos - 1
@@ -167,7 +179,7 @@ enddef
 #
 # Note: The source string has all lines joined by "\n" so "\r" can be ignored
 # ------------------------------------------------------------------------------
-def SkipWhitespace(scanner: dict<any>)
+def SkipWhitespace(scanner: Scanner)
     var newlines = 0
     while !scanner.at_eof
         const nr = scanner.cur_char_nr
@@ -190,7 +202,7 @@ enddef
 #
 # Note: The source string has all lines joined by "\n" so "\r" can be ignored
 # ------------------------------------------------------------------------------
-def ReadComment(scanner: dict<any>): Token
+def ReadComment(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char == ';', "Not the start of a comment", scanner.pos) | endif
 
     const start_pos = scanner.pos
@@ -212,7 +224,7 @@ def IsDigit(char_nr: number): bool
     return 48 <= char_nr && char_nr <= 57
 enddef
 
-def ReadNumber(scanner: dict<any>): Token
+def ReadNumber(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char_nr->IsDigit(), "Not the start of a number", scanner.pos) | endif
 
     const starts_with_zero = scanner.cur_char == '0'
@@ -260,7 +272,7 @@ def InitIsAlphaNumericCharNr(): list<bool>
 enddef
 const is_alphanumeric_char_nr = InitIsAlphaNumericCharNr()
 
-def ReadBv(scanner: dict<any>): Token
+def ReadBv(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char == '#', "Not the start of a bit vector literal", scanner.pos) | endif
 
     const start_pos = scanner.pos
@@ -276,10 +288,10 @@ def ReadBv(scanner: dict<any>): Token
     elseif scanner.cur_char == 'b'
         scanner->NextPos()
         # '0'->char2nr() == 48 && '1'->char2nr() == 49
-        scanner->Enforce(!scanner.at_eof && scanner.cur_char_num == 48 || scanner.cur_char_num == 49,
+        scanner->Enforce(!scanner.at_eof && scanner.cur_char_nr == 48 || scanner.cur_char_nr == 49,
             "binary literal may not be empty",
             scanner.pos)
-        while !scanner.at_eof && scanner.cur_char_num == 48 || scanner.cur_char_num == 49
+        while !scanner.at_eof && scanner.cur_char_nr == 48 || scanner.cur_char_nr == 49
             scanner->NextPos()
         endwhile
     else
@@ -293,7 +305,7 @@ enddef
 #              quotes with escape sequence ""
 # ------------------------------------------------------------------------------
 # TODO: Allow only printable characters, i.e. ranges [32, 126], [128-255]?
-def ReadString(scanner: dict<any>): Token
+def ReadString(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char == '"', "Not the start of a string", scanner.pos) | endif
 
     const start_pos = scanner.pos
@@ -335,7 +347,7 @@ def IsStartOfSimpleSymbol(char_nr: number): bool
     return is_simple_symbol_char_nr[char_nr] && !(48 <= char_nr && char_nr <= 57)
 enddef
 
-def ReadSimpleSymbol(scanner: dict<any>): Token
+def ReadSimpleSymbol(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char_nr->IsStartOfSimpleSymbol(), "Not the start of a simple symbol", scanner.pos) | endif
 
     const start_pos = scanner.pos
@@ -352,7 +364,7 @@ enddef
 #              and ends with '|' and does not otherwise include '|' or '\'
 # ------------------------------------------------------------------------------
 # TODO: Allow only printable characters, i.e. ranges [32, 126], [128-255]?
-def ReadQuotedSymbol(scanner: dict<any>): Token
+def ReadQuotedSymbol(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char == '|', "Not the start of a quoted symbol", scanner.pos) | endif
 
     const start_pos = scanner.pos
@@ -372,7 +384,7 @@ enddef
 # ------------------------------------------------------------------------------
 # <keyword> ::= :<simple symbol>
 # ------------------------------------------------------------------------------
-def ReadKeyword(scanner: dict<any>): Token
+def ReadKeyword(scanner: Scanner): Token
     if debug | scanner->Enforce(scanner.cur_char == ':', "Not the start of a keyword", scanner.pos) | endif
 
     const start_pos = scanner.pos


### PR DESCRIPTION
When the initial auto-formatting implementation was written vim9script was still experimental and `dict<any>` was the only option to express "structs".
#8 is a result of the [runtime checks that were introduced to safeguard working with such types](https://github.com/vim/vim/issues/11753#issuecomment-1368219440).

By now, vim9script also features a `class` construct that does not need runtime checks.
This PR uses `class` instead of `dict<any>` to express "structs".
This not only fixes the performance degradation but actually improves the parsing and formatting times beyond what we had initially.

Closes #8 

_Note: `class` is actually not what we always want but `tuple` is not supported yet._