### PR TITLE
Follow SMT-LIB spec for string highlighting

### DIFF
--- a/syntax/smt2.vim
+++ b/syntax/smt2.vim
@@ -143,7 +143,7 @@ syntax match smt2Identifier "\m\C\<[a-z_][a-zA-Z0-9_\-\.']*\>"
 syntax match smt2Type "\m\C\<[A-Z][a-zA-Z0-9_\-\.']*\>"
 
 " Strings
-syntax region smt2String start=+"+ skip=+\\\\\|\\"+ end=+"+
+syntax region smt2String start=+"+ skip=+""+ end=+"+
 syntax match smt2Option "\m\C\<:[a-zA-Z0-9_\-\.']*\>"
 
 " Constructors


### PR DESCRIPTION
This PR switches from the regex that was originally used in [Z3's old online demo](https://rise4fun.com/Z3/), which supports escaping via `\`, to [what the SMT-LIB spec actually specifies](https://smt-lib.org/papers/smt-lib-reference-v2.7-r2025-04-09.pdf#section.3.1):
> A ⟨string ⟩ (literal) is any sequence of characters from ⟨printable_char ⟩ or ⟨white_space_char ⟩ delimited by the double quote character `"` (34dec). The character `"` can itself occur within a string literal only if duplicated. In other words, after an initial `"` that starts a literal, a lexer should treat the sequence `""` as an escape sequence denoting a single occurrence of `"` within the literal. SMT-LIB string literals are akin to raw strings in certain programming languages. However, they have only one escape sequence: `""` . This means, for example and in contrast to most programming languages, that within a ⟨string ⟩ the character sequences `\n`, `\012`, `\x0A`, and `\u0008` are not escape sequences (all denoting the new line character), but regular sequences denoting their individual characters

Closes #10 and results in the following highlighting

<img width="850" alt="Screenshot 2025-05-06 at 21 56 36" src="https://github.com/user-attachments/assets/3bdc46e3-f5d8-456d-8b94-7c96493eb569" />

